### PR TITLE
Conflicting routes

### DIFF
--- a/api_caller/views.py
+++ b/api_caller/views.py
@@ -10,7 +10,7 @@ import json
 
 with open('bus_routes/finalRoutesAndIds.json') as all_routes:
     route_data = json.load(all_routes)
-    # print(route_data)
+    print(route_data)
 
 #def voice_to_text(path):
  #   sound = path
@@ -200,8 +200,12 @@ def clean_route_data(lat, lon, bus_route):
             bus_route += 'pt'
         else: # going to be intercity transit
             bus_route += 'it'
+    
+    try:
+        return {'bus_id':route_data[bus_route], 'user_lat':user_lat, 'user_lon':user_lon, 'bus_route': bus_route}
+    except:
+        return None
 
-    return {'bus_id':route_data[bus_route], 'user_lat':user_lat, 'user_lon':user_lon, 'bus_route': bus_route}
 
 def clean_route_data_deprecated(lat, lon, bus_route):
     # Clean input


### PR DESCRIPTION
Added logic for the conflicting routes in clean_data (views.py).
Logic based on latitude (north/south)
Found a bug. The code was picking the first stop as the closest always. And updating closest/next closest as you looped through the list of stops. This failed if the first stop in the list WAS the actual closest. The NEXT_CLOSEST was NEVER updated in that case.
Refactored the find_closest_stops (views.py) to fix bug.
Tested (N/S) working locally!